### PR TITLE
Add MQTT LWT to v1.4.7

### DIFF
--- a/demos/common/mqtt/aws_hello_world.c
+++ b/demos/common/mqtt/aws_hello_world.c
@@ -113,6 +113,32 @@
  */
 #define echoDONT_BLOCK           ( ( TickType_t ) 0 )
 
+
+#define IOT_DEMO_MQTT_TOPIC_PREFIX           "iotdemo"
+
+/**
+ * @brief The Last Will and Testament topic name in this demo.
+ *
+ * The MQTT server will publish a message to this topic name if this client is
+ * unexpectedly disconnected.
+ */
+#define WILL_TOPIC_NAME                          IOT_DEMO_MQTT_TOPIC_PREFIX "/will"
+
+/**
+ * @brief The length of #WILL_TOPIC_NAME.
+ */
+#define WILL_TOPIC_NAME_LENGTH                   ( ( uint16_t ) ( sizeof( WILL_TOPIC_NAME ) - 1 ) )
+
+/**
+ * @brief The message to publish to #WILL_TOPIC_NAME.
+ */
+#define WILL_MESSAGE                             "MQTT demo unexpectedly disconnected."
+
+/**
+ * @brief The length of #WILL_MESSAGE.
+ */
+#define WILL_MESSAGE_LENGTH                      ( ( size_t ) ( sizeof( WILL_MESSAGE ) - 1 ) )
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -184,6 +210,7 @@ static BaseType_t prvCreateClientAndConnectToBroker( void )
 {
     MQTTAgentReturnCode_t xReturned;
     BaseType_t xReturn = pdFAIL;
+    MQTTPublishParams_t willInfo;
     MQTTAgentConnectParams_t xConnectParameters =
     {
         clientcredentialMQTT_BROKER_ENDPOINT, /* The URL of the MQTT broker to connect to. */
@@ -196,8 +223,16 @@ static BaseType_t prvCreateClientAndConnectToBroker( void )
         NULL,                                 /* User data supplied to the callback. Can be NULL. */
         NULL,                                 /* Callback used to report various events. Can be NULL. */
         NULL,                                 /* Certificate used for secure connection. Can be NULL. */
-        0                                     /* Size of certificate used for secure connection. */
+        0,                                    /* Size of certificate used for secure connection. */
+        &willInfo                             /* MQTT LWT information. */
     };
+
+    /* Add topic, message for MQTT LWT.  */
+    willInfo.pucTopic = WILL_TOPIC_NAME;
+    willInfo.usTopicLength = WILL_TOPIC_NAME_LENGTH;
+    willInfo.pvData = WILL_MESSAGE;
+    willInfo.ulDataLength = WILL_MESSAGE_LENGTH;
+    willInfo.xQos = eMQTTQoS0;
 
     /* Check this function has not already been executed. */
     configASSERT( xMQTTHandle == NULL );

--- a/lib/include/aws_mqtt_agent.h
+++ b/lib/include/aws_mqtt_agent.h
@@ -134,18 +134,19 @@ typedef BaseType_t ( * MQTTAgentCallback_t ) ( void * pvUserData,
  */
 typedef struct MQTTAgentConnectParams
 {
-    const char * pcURL;             /**< The URL of the MQTT broker to connect to. */
-    BaseType_t xFlags;              /**< Flags to control the behavior of MQTT connect. */
-    BaseType_t xURLIsIPAddress;     /**< Deprecated. Set the mqttagentURL_IS_IP_ADDRESS bit in xFlags instead. */
-    uint16_t usPort;                /**< Port number at which MQTT broker is listening. This field is ignored if the mqttagentUSE_AWS_IOT_ALPN_443 flag is set. */
-    const uint8_t * pucClientId;    /**< Client Identifier of the MQTT client. It should be unique per broker. */
-    uint16_t usClientIdLength;      /**< The length of the client Id. */
-    BaseType_t xSecuredConnection;  /**< Deprecated. Set the mqttagentREQUIRE_TLS bit in xFlags instead. */
-    void * pvUserData;              /**< User data supplied back as it is in the callback. Can be NULL. */
-    MQTTAgentCallback_t pxCallback; /**< Callback used to report various events. In addition to other events, this callback is invoked for the publish
-                                     *   messages received on the topics for which the user has not registered any subscription callback. Can be NULL. */
-    char * pcCertificate;           /**< Certificate used for secure connection. Can be NULL. If it is NULL, the one specified in the aws_credential_keys.h is used. */
-    uint32_t ulCertificateSize;     /**< Size of certificate used for secure connection. */
+    const char * pcURL;                             /**< The URL of the MQTT broker to connect to. */
+    BaseType_t xFlags;                              /**< Flags to control the behavior of MQTT connect. */
+    BaseType_t xURLIsIPAddress;                     /**< Deprecated. Set the mqttagentURL_IS_IP_ADDRESS bit in xFlags instead. */
+    uint16_t usPort;                                /**< Port number at which MQTT broker is listening. This field is ignored if the mqttagentUSE_AWS_IOT_ALPN_443 flag is set. */
+    const uint8_t * pucClientId;                    /**< Client Identifier of the MQTT client. It should be unique per broker. */
+    uint16_t usClientIdLength;                      /**< The length of the client Id. */
+    BaseType_t xSecuredConnection;                  /**< Deprecated. Set the mqttagentREQUIRE_TLS bit in xFlags instead. */
+    void * pvUserData;                              /**< User data supplied back as it is in the callback. Can be NULL. */
+    MQTTAgentCallback_t pxCallback;                 /**< Callback used to report various events. In addition to other events, this callback is invoked for the publish
+                                                     *   messages received on the topics for which the user has not registered any subscription callback. Can be NULL. */
+    char * pcCertificate;                           /**< Certificate used for secure connection. Can be NULL. If it is NULL, the one specified in the aws_credential_keys.h is used. */
+    uint32_t ulCertificateSize;                     /**< Size of certificate used for secure connection. */
+    const MQTTPublishParams_t * pWillInfo;          /**< A message to publish if the new MQTT connection is unexpectedly closed. */
 } MQTTAgentConnectParams_t;
 
 /**
@@ -355,5 +356,15 @@ MQTTAgentReturnCode_t MQTT_AGENT_Publish( MQTTAgentHandle_t xMQTTHandle,
  */
 MQTTAgentReturnCode_t MQTT_AGENT_ReturnBuffer( MQTTAgentHandle_t xMQTTHandle,
                                                MQTTBufferHandle_t xBufferHandle );
+/**
+ * @brief used to shutdown the socket directly.
+ *
+ * This function is used to shutdown socket connection without closing it.
+ *
+ * @param[in] xMQTTHandle The opaque handle as returned from MQTT_AGENT_Create.
+ *
+ */
+
+void prvShutdownConnection( MQTTAgentHandle_t xMQTTHandle );
 
 #endif /* _AWS_MQTT_AGENT_H_ */

--- a/lib/include/aws_mqtt_lib.h
+++ b/lib/include/aws_mqtt_lib.h
@@ -510,6 +510,23 @@ typedef struct MQTTInitParams
 } MQTTInitParams_t;
 
 /**
+ * @brief MQTT Publish Parameters.
+ *
+ * Parameters passed to the MQTT_Publish API.
+ */
+typedef struct MQTTPublishParams
+{
+    const uint8_t * pucTopic;    /**< The topic to which the data should be published. */
+    uint16_t usTopicLength;      /**< The length of the topic. */
+    MQTTQoS_t xQos;              /**< Quality of Service. */
+    const void * pvData;         /**< The data to publish. */
+    uint32_t ulDataLength;       /**< Length of the data. */
+    uint16_t usPacketIdentifier; /**< The same identifier is returned in the callback when corresponding PUBACK is received or the operation times out. */
+    uint32_t ulTimeoutTicks;     /**< The time interval in ticks after which the operation should fail. */
+} MQTTPublishParams_t;
+
+
+/**
  * @brief MQTT Connect Parameters.
  *
  * Parameters passed to the MQTT_Connect API.
@@ -525,6 +542,7 @@ typedef struct MQTTConnectParams
     uint16_t usUserNameLength;               /**< The length of the user name. */
     uint16_t usPacketIdentifier;             /**< The same identifier is returned in the callback when corresponding CONNACK is received or the operation times out. */
     uint32_t ulTimeoutTicks;                 /**< The time interval in ticks after which the operation should fail. */
+    const MQTTPublishParams_t * pWillInfo;   /**< A message to publish if the new MQTT connection is unexpectedly closed. */
 } MQTTConnectParams_t;
 
 /**
@@ -561,21 +579,7 @@ typedef struct MQTTUnsubscribeParams
     uint32_t ulTimeoutTicks;     /**< The time interval in ticks after which the operation should fail. */
 } MQTTUnsubscribeParams_t;
 
-/**
- * @brief MQTT Publish Parameters.
- *
- * Parameters passed to the MQTT_Publish API.
- */
-typedef struct MQTTPublishParams
-{
-    const uint8_t * pucTopic;    /**< The topic to which the data should be published. */
-    uint16_t usTopicLength;      /**< The length of the topic. */
-    MQTTQoS_t xQos;              /**< Quality of Service. */
-    const void * pvData;         /**< The data to publish. */
-    uint32_t ulDataLength;       /**< Length of the data. */
-    uint16_t usPacketIdentifier; /**< The same identifier is returned in the callback when corresponding PUBACK is received or the operation times out. */
-    uint32_t ulTimeoutTicks;     /**< The time interval in ticks after which the operation should fail. */
-} MQTTPublishParams_t;
+
 
 /**
  * @brief Initializes the given MQTT Context.

--- a/lib/mqtt/aws_mqtt_agent.c
+++ b/lib/mqtt/aws_mqtt_agent.c
@@ -1402,6 +1402,7 @@ static void prvInitiateMQTTConnect( MQTTEventData_t * const pxEventData )
             xConnectParams.ulPingRequestTimeoutTicks = mqttconfigKEEP_ALIVE_TIMEOUT_TICKS;
             xConnectParams.usPacketIdentifier = ( uint16_t ) ( mqttMESSAGE_IDENTIFIER_EXTRACT( pxEventData->xNotificationData.ulMessageIdentifier ) );
             xConnectParams.ulTimeoutTicks = pxEventData->xTicksToWait;
+            xConnectParams.pWillInfo = pxEventData->u.pxConnectParams->pWillInfo;
 
             if( MQTT_Connect( &( pxConnection->xMQTTContext ), &( xConnectParams ) ) != eMQTTSuccess )
             {
@@ -2065,5 +2066,20 @@ MQTTAgentReturnCode_t MQTT_AGENT_ReturnBuffer( MQTTAgentHandle_t xMQTTHandle,
 
     /* Return success. */
     return eMQTTAgentSuccess;
+}
+/*-----------------------------------------------------------*/
+
+void prvShutdownConnection( MQTTAgentHandle_t xMQTTHandle )
+{
+    UBaseType_t uxBrokerNumber = ( UBaseType_t ) mqttDECODE_BROKER_NUMBER( xMQTTHandle ); /*lint !e923 Opaque pointer. */
+
+    MQTTBrokerConnection_t * pxConnection = &( xMQTTConnections[ uxBrokerNumber ] );
+
+    mqttconfigDEBUG_LOG( ( "start to shutdown socket.\r\n" ) );
+
+    /* Shutdown the connection. */
+    ( void ) SOCKETS_Shutdown( pxConnection->xSocket, SOCKETS_SHUT_RDWR );
+
+    pxConnection->xSocket = SOCKETS_INVALID_SOCKET;
 }
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
1. Let MQTT AGENT support MQTT LWT while handling CONNECT request.
2. Integrate MQTT LWT example with aws_hello_world.c
3. Integrate MQTT LWT test item to make sure it's qualified as well as the
same one in IDT 1.5.0.