### PR TITLE
Fix hardfault in demo when ATWD is issued 

### DIFF
--- a/demos/coreHTTP/http_demo_mutual_auth.c
+++ b/demos/coreHTTP/http_demo_mutual_auth.c
@@ -321,6 +321,9 @@ int RunCoreHttpMutualAuthDemo( bool awsIotMqttMode,
                 LogError( ( "SecureSocketsTransport_Disconnect() failed to close the network connection. "
                             "StatusCode=%d.", ( int ) xNetworkStatus ) );
             }
+
+            /* Reset the connection flag back to false */
+            xIsConnectionEstablished = pdFALSE;
         }
 
         /* Increment the demo run count. */

--- a/demos/coreHTTP/http_demo_s3_download.c
+++ b/demos/coreHTTP/http_demo_s3_download.c
@@ -775,6 +775,9 @@ int RunCoreHttpS3DownloadDemo( bool awsIotMqttMode,
                 LogError( ( "SecureSocketsTransport_Disconnect() failed to close the network connection. "
                             "StatusCode=%d.", ( int ) xNetworkStatus ) );
             }
+
+            /* Reset the connection flag back to false */
+            xIsConnectionEstablished = pdFALSE;
         }
 
         /* Increment the demo run count. */

--- a/demos/coreHTTP/http_demo_s3_download_multithreaded.c
+++ b/demos/coreHTTP/http_demo_s3_download_multithreaded.c
@@ -1059,6 +1059,9 @@ int RunCoreHttpS3DownloadMultithreadedDemo( bool awsIotMqttMode,
                             "StatusCode=%d.", ( int ) xNetworkStatus ) );
                 xDemoStatus = pdFAIL;
             }
+
+            /* Reset the connection flag back to false */
+            xIsConnectionEstablished = pdFALSE;
         }
 
         /*********** Clean up and evaluate demo iteration status. ***********/

--- a/demos/coreHTTP/http_demo_s3_upload.c
+++ b/demos/coreHTTP/http_demo_s3_upload.c
@@ -815,6 +815,9 @@ int RunCoreHttpS3UploadDemo( bool awsIotMqttMode,
                 LogError( ( "SecureSocketsTransport_Disconnect() failed to close the network connection. "
                             "StatusCode=%d.", ( int ) xNetworkStatus ) );
             }
+
+            /* Reset the connection flag back to false */
+            xIsConnectionEstablished = pdFALSE;
         }
 
         /* Increment the demo run count. */

--- a/demos/coreMQTT/mqtt_demo_mutual_auth.c
+++ b/demos/coreMQTT/mqtt_demo_mutual_auth.c
@@ -616,6 +616,9 @@ int RunCoreMqttMutualAuthDemo( bool awsIotMqttMode,
                 LogError( ( "SecureSocketsTransport_Disconnect() failed to close the network connection. "
                             "StatusCode=%d.", ( int ) xNetworkStatus ) );
             }
+
+            /* Reset the connection flag back to false */
+            xIsConnectionEstablished = pdFALSE;
         }
 
         /* Reset SUBACK status for each topic filter after completion of subscription request cycle. */

--- a/demos/fleet_provisioning_with_csr/fleet_provisioning_demo.c
+++ b/demos/fleet_provisioning_with_csr/fleet_provisioning_demo.c
@@ -864,6 +864,9 @@ int RunFleetProvisioningDemo( bool awsIotMqttMode,
             LogError( ( "SecureSocketsTransport_Disconnect() failed to close the network connection. "
                         "StatusCode=%d.\n", ( int ) xNetworkStatus ) );
         }
+
+        /* Reset the connection flag back to false */
+            xIsConnectionEstablished = pdFALSE;
     }
     return ( xDemoStatus == pdPASS ) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
+++ b/libraries/abstractions/transport/secure_sockets/transport_secure_sockets.c
@@ -567,20 +567,17 @@ TransportSocketStatus_t SecureSocketsTransport_Disconnect( const NetworkContext_
             shutdownStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
         }
 
-        if(shutdownStatus == TRANSPORT_SOCKET_STATUS_SUCCESS)
-        {
-            /* Call Secure Sockets close function to close socket. */
-            transportSocketStatus = SOCKETS_Close( pSecureSocketsTransportParams->tcpSocket );
+        /* Call Secure Sockets close function to close socket. */
+        transportSocketStatus = SOCKETS_Close( pSecureSocketsTransportParams->tcpSocket );
 
-            if( transportSocketStatus != ( int32_t ) SOCKETS_ERROR_NONE )
-            {
-                LogError( ( "Failed to close connection: SOCKETS_Close call failed. transportSocketStatus %d", transportSocketStatus ) );
-                closeStatus = TRANSPORT_SOCKET_STATUS_INTERNAL_ERROR;
-            }
-            else
-            {
-                closeStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
-            }
+        if( transportSocketStatus != ( int32_t ) SOCKETS_ERROR_NONE )
+        {
+            LogError( ( "Failed to close connection: SOCKETS_Close call failed. transportSocketStatus %d", transportSocketStatus ) );
+            closeStatus = TRANSPORT_SOCKET_STATUS_INTERNAL_ERROR;
+        }
+        else
+        {
+            closeStatus = TRANSPORT_SOCKET_STATUS_SUCCESS;
         }
 
         if( ( shutdownStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) || ( closeStatus != TRANSPORT_SOCKET_STATUS_SUCCESS ) )

--- a/vendors/realtek/boards/amebaZ2/ports/secure_sockets/iot_secure_sockets.c
+++ b/vendors/realtek/boards/amebaZ2/ports/secure_sockets/iot_secure_sockets.c
@@ -331,11 +331,6 @@ int32_t SOCKETS_Connect( Socket_t xSocket,
 
     ctx = ( ss_ctx_t * )xSocket;
 
-    if( NULL == ctx )
-    {
-        return SOCKETS_SOCKET_ERROR;
-    }
-
     if( 0 <= ctx->ip_socket )
     {
         struct sockaddr_in sa_addr = { 0 };
@@ -413,11 +408,6 @@ int32_t SOCKETS_Recv( Socket_t xSocket,
 {
     ss_ctx_t * ctx = ( ss_ctx_t * )xSocket;
 
-    if( NULL == ctx )
-    {
-        return SOCKETS_SOCKET_ERROR;
-    }
-
     if( SOCKETS_INVALID_SOCKET == xSocket )
     {
         return SOCKETS_SOCKET_ERROR;
@@ -472,16 +462,6 @@ int32_t SOCKETS_Send( Socket_t xSocket,
 
     ctx            = ( ss_ctx_t * )xSocket;
 
-    if( NULL == ctx )
-    {
-        return SOCKETS_SOCKET_ERROR;
-    }
-
-    if( ( ctx->status & SS_STATUS_CONNECTED ) != SS_STATUS_CONNECTED )
-    {
-        return SOCKETS_ENOTCONN;
-    }
-
     ctx->send_flag = ulFlags;
 
     if( 0 > ctx->ip_socket )
@@ -515,11 +495,6 @@ int32_t SOCKETS_Shutdown( Socket_t xSocket,
 
     ctx            = ( ss_ctx_t * )xSocket;
 
-    if( NULL == ctx )
-    {
-        return SOCKETS_SOCKET_ERROR;
-    }
-
     if( 0 > ctx->ip_socket )
     {
         return SOCKETS_SOCKET_ERROR;
@@ -549,11 +524,6 @@ int32_t SOCKETS_Close( Socket_t xSocket )
     }
 
     ctx = ( ss_ctx_t * )xSocket;
-
-    if( NULL == ctx )
-    {
-        return SOCKETS_SOCKET_ERROR;
-    }
 
     /* Clean-up application protocol array. */
     if( NULL != ctx->ppcAlpnProtocols )
@@ -630,11 +600,6 @@ int32_t SOCKETS_SetSockOpt( Socket_t xSocket,
     }
 
     ctx            = ( ss_ctx_t * )xSocket;
-
-    if( NULL == ctx )
-    {
-        return SOCKETS_SOCKET_ERROR;
-    }
 
     if( 0 > ctx->ip_socket )
     {


### PR DESCRIPTION
Fix undos the earlier workaround made which was observed to still cause memleak.
After applying fix, heap is observed to be stable and survives multiple connect/disconnect within a single demo

List of demos that are supported. Fix is also applied to demos that do not run in a loop for completeness

```
aws_demo_config.h

//#define CONFIG_CORE_HTTP_MUTUAL_AUTH_DEMO_ENABLED   # does not run in a loop, so it will not reattempt a 2nd pass if disconnect
//#define CONFIG_CORE_MQTT_MUTUAL_AUTH_DEMO_ENABLED   # ATWD: Crash if No fix, Stable if fix
//#define CONFIG_DEVICE_SHADOW_DEMO_ENABLED           # does not contain xIsConnectionEstablished
//#define CONFIG_DEVICE_DEFENDER_DEMO_ENABLED         # does not contain xIsConnectionEstablished
//#define CONFIG_OTA_MQTT_UPDATE_DEMO_ENABLED	      # does not contain xIsConnectionEstablished
//#define CONFIG_OTA_HTTP_UPDATE_DEMO_ENABLED	      # does not contain xIsConnectionEstablished
//#define CONFIG_JOBS_DEMO_ENABLED                    # does not contain xIsConnectionEstablished
//#define CONFIG_FLEET_PROVISIONING_DEMO_ENABLED      # does not run in a loop, so it will not reattempt a 2nd pass if disconnect
//#define CONFIG_CORE_MQTT_AGENT_DEMO_ENABLED         # does not contain xIsConnectionEstablished
```